### PR TITLE
Fix issue689

### DIFF
--- a/resources/test_data.json
+++ b/resources/test_data.json
@@ -317,7 +317,7 @@
         "root_dir": "", 
         "targets": [
             {
-                "method": "listIterator(SubList<E>, int)",
+                "method": "listIterator(int)",
                 "file": "AbstractList.java",
                 "package": "java.util",
                 "inner_class": "SubList"


### PR DESCRIPTION
Dear @tahiat,

This PR is not ready for merge. We also need to change the .json file somehow so that the target method signature will be: `java.util.SubList#listIterator(int)`. SubList is a class inside AbstractList.java, but it is not an inner class. I don't know how to change the .json file to reflect that fact.

Thank you for your time.