### PR TITLE
Add inner class for cf-6388

### DIFF
--- a/resources/test_data.json
+++ b/resources/test_data.json
@@ -340,7 +340,7 @@
                 "method": "via(Contextful<Fn<UserT, OutputT>>, Contextful<Fn<DestinationT, Sink<OutputT>>>)",
                 "file": "FileIO.java",
                 "package": "org.apache.beam.sdk.io",
-                "inner_class": ""
+                "inner_class": "Write"
             }
         ],
         "cf_version": "3.40.0",


### PR DESCRIPTION
Hello @tahiat,
 
Method `via` is inside inner class `Write`. The change in this PR reflects that fact. Please take a look. Thank you.